### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Manual Worflow.yml
+++ b/.github/workflows/Manual Worflow.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI or API.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Teamelite12/GitHub-Mobile/security/code-scanning/1](https://github.com/Teamelite12/GitHub-Mobile/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it appears that the jobs only need to read repository contents and do not require write access. Therefore, we will set `contents: read` at the workflow level. If additional permissions are required for specific jobs, they can be defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
